### PR TITLE
Broaden chatbot CV coverage and relax safety filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.294.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^9.1.0",
         "react-vertical-timeline-component": "^3.6.0",
         "tailwind-merge": "^2.0.0"
       },
@@ -1997,6 +1998,15 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2008,14 +2018,46 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2034,14 +2076,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2063,6 +2103,12 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2267,7 +2313,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2613,6 +2658,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2802,6 +2857,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
@@ -2834,6 +2899,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -2985,6 +3090,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "13.1.0",
@@ -3169,7 +3284,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3227,7 +3341,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3247,6 +3360,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3279,7 +3405,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3290,6 +3415,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3721,6 +3859,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3803,6 +3951,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4349,6 +4503,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4360,6 +4554,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -4503,6 +4707,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4511,6 +4721,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -4540,6 +4774,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -4575,6 +4819,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4593,6 +4847,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4872,6 +5138,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4967,6 +5243,159 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -4999,6 +5428,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5087,7 +5958,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5404,6 +6274,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -5844,6 +6739,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5978,6 +6883,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -6104,6 +7036,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -6562,6 +7527,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6654,6 +7629,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -6750,6 +7739,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/sucrase": {
@@ -7108,6 +8115,16 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -7129,6 +8146,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7227,6 +8254,93 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -7347,6 +8461,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -7863,6 +9005,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.294.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-markdown": "^9.1.0",
     "react-vertical-timeline-component": "^3.6.0",
     "tailwind-merge": "^2.0.0"
   },

--- a/server.js
+++ b/server.js
@@ -5,372 +5,139 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
 
-// Load environment variables
 dotenv.config();
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Load CV data
-let cvData = null;
+// Load CV data once at startup
+let cvData = {};
 try {
-  const cvDataPath = path.join(process.cwd(), 'cv_json_data.json');
-  const cvDataRaw = fs.readFileSync(cvDataPath, 'utf8');
-  cvData = JSON.parse(cvDataRaw);
-  console.log('CV Data Loaded: Yes');
-  console.log('CV Data Keys:', Object.keys(cvData));
-} catch (error) {
-  console.error('Error loading CV data:', error.message);
-  cvData = null;
+  const cvPath = path.join(process.cwd(), 'cv_json_data.json');
+  cvData = JSON.parse(fs.readFileSync(cvPath, 'utf8'));
+  console.log('CV data loaded. Sections:', Object.keys(cvData).length);
+} catch (err) {
+  console.error('Failed to load CV data:', err.message);
 }
 
-const openai = new OpenAI({
-  apiKey: process.env.VITE_OPENAI_API_KEY
-});
+const openai = new OpenAI({ apiKey: process.env.VITE_OPENAI_API_KEY });
+const MODEL = 'gpt-4o-mini';
 
-// Backend safety filtering (adapted from src/utils/safety.ts)
-const ACCEPTABLE_TOPICS = [
-  // Core professional topics
-  /john\s+britton/i,
-  /education/i,
-  /degree/i,
-  /psychology/i,
-  /psych/i,
-  /clinical/i,
-  /therapy/i,
-  /music.therapy/i,
-  /research/i,
-  /experience/i,
-  /training/i,
-  /internship/i,
-  /appic/i,
-  /supervision/i,
-  /assessment/i,
-  /evaluation/i,
-  /treatment/i,
-  /evidence.based/i,
-  /cv|resume/i,
-  /background/i,
-  /qualifications/i,
-  /skills/i,
-  /competencies/i,
-  /strength/i,
-  /weakness/i,
-  /challenge/i,
-  /growth/i,
-  /development/i,
-  /professional/i,
-  /career/i,
-  /goals/i,
-  /interests/i,
-  /approach/i,
-  /philosophy/i,
-  /values/i,
-  /dissertation/i,
-  /thesis/i,
-  /publication/i,
-  /presentation/i,
-  /conference/i,
-  /client/i,
-  /patient/i,
-  /population/i,
-  /intervention/i,
-  /cognitive/i,
-  /behavioral/i,
-  /trauma/i,
-  /anxiety/i,
-  /depression/i,
-  /psychotherapy/i,
-  /site/i,
-  /program/i,
-  /supervisor/i,
-  /mentor/i,
-  /placement/i,
-  /rotation/i,
-  /practicum/i,
-  /hours/i,
-  /licensing/i,
-  /certification/i,
-  // Psychology specialties and settings
-  /health.psychology/i,
-  /health.psych/i,
-  /medical.psychology/i,
-  /behavioral.medicine/i,
-  /neuropsychology/i,
-  /forensic.psychology/i,
-  /school.psychology/i,
-  /counseling.psychology/i,
-  /rehabilitation.psychology/i,
-  /pediatric.psychology/i,
-  /geropsychology/i,
-  /community.psychology/i,
-  /hospital/i,
-  /medical.center/i,
-  /healthcare/i,
-  /outpatient/i,
-  /inpatient/i,
-  /setting/i,
-  /environment/i,
-  /workplace/i,
-  /facility/i,
-  /clinic/i,
-  /practice/i,
-  /fit/i,
-  /suitable/i,
-  /appropriate/i,
-  /match/i,
-  /compatible/i,
-  // Question words and phrases
-  /why/i,
-  /how/i,
-  /what/i,
-  /when/i,
-  /where/i,
-  /who/i,
-  /tell.me/i,
-  /describe/i,
-  /explain/i,
-  /discuss/i,
-  /share/i,
-  /contact/i,
-  /phone/i,
-  /email/i,
-  /address/i,
-  /reference/i,
-  /recommendation/i
-];
-
-const FORBIDDEN_PATTERNS = [
-  /money|payment|cost|fee|price|insurance|billing|financial|charge|salary|wage|income|reimbursement|claim/i,
-  /suicide|self[- ]?harm|kill myself|hurt myself|ending my life|overdose|cutting|risk of harm|homicide|violence|abuse|assault|danger to self|danger to others|crisis|emergency|911|hotline/i
-];
-
-const isRelevantQuery = (query) => {
-  const lowerQuery = query.toLowerCase();
-  
-  // Check if query contains any acceptable topics
-  const isTopicRelevant = ACCEPTABLE_TOPICS.some(pattern => pattern.test(lowerQuery));
-  
-  // Allow general conversational starters
-  const conversationalStarters = [
-    /^(hi|hello|hey|good morning|good afternoon|good evening)/i,
-    /^(can you|could you|would you|will you)/i,
-    /^(i would like|i want to|i need to)/i,
-    /^(please|thank you|thanks)/i
-  ];
-  
-  const isConversational = conversationalStarters.some(pattern => pattern.test(lowerQuery));
-  
-  // Reject clearly unrelated topics
-  const unrelatedTopics = [
-    /weather/i,
-    /sports/i,
-    /politics/i,
-    /cooking/i,
-    /travel/i,
-    /movies/i,
-    /music(?!.*therapy)/i, // Allow music therapy but not general music
-    /technology(?!.*clinical)/i, // Allow clinical technology
-    /shopping/i,
-    /fashion/i,
-    /celebrity/i,
-    /gossip/i,
-    /news(?!.*psychology)/i
-  ];
-  
-  const isUnrelated = unrelatedTopics.some(pattern => pattern.test(lowerQuery));
-  
-  return (isTopicRelevant || isConversational) && !isUnrelated;
+// --- Response formatter to keep paragraphs short ---
+const formatResponse = (text) => {
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const paragraphs = [];
+  let current = [];
+  for (const sentence of sentences) {
+    current.push(sentence);
+    if (current.length >= 2) {
+      paragraphs.push(current.join(' '));
+      current = [];
+    }
+  }
+  if (current.length) paragraphs.push(current.join(' '));
+  return paragraphs.join('\n\n');
 };
+
+// --- Simple RAG implementation ---
+const createChunks = (data) => {
+  const chunks = [];
+  let id = 0;
+  const addChunk = (content, section, source) => {
+    chunks.push({ id: `chunk-${id++}`, content, section, source });
+  };
+
+  Object.entries(data).forEach(([section, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        const source = item.organization || item.title || item.name || section;
+        const parts = [];
+        Object.entries(item).forEach(([key, val]) => {
+          if (Array.isArray(val)) parts.push(`${key}: ${val.join(', ')}`);
+          else parts.push(`${key}: ${val}`);
+        });
+        addChunk(parts.join('. '), section, source);
+      });
+    } else if (typeof value === 'object' && value !== null) {
+      const parts = Object.entries(value).map(([k, v]) => `${k}: ${v}`);
+      addChunk(parts.join('. '), section, section);
+    }
+  });
+  return chunks;
+};
+
+const allChunks = createChunks(cvData);
+
+const searchChunks = (query, chunks) => {
+  const words = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+  return chunks
+    .map(chunk => {
+      const text = chunk.content.toLowerCase();
+      let score = 0;
+      words.forEach(w => { if (text.includes(w)) score += 1; });
+      return { ...chunk, score };
+    })
+    .filter(c => c.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8);
+};
+
+const getRelevantChunks = (query) => searchChunks(query, allChunks).slice(0, 6);
+
+// --- Minimal safety filter ---
+const FORBIDDEN_PATTERNS = [
+  /suicide|self[- ]?harm|kill myself|hurt myself|ending my life|overdose|cutting|risk of harm|homicide|violence|abuse|assault|danger to self|danger to others|crisis|emergency|911|hotline/i,
+  /credit card|ssn|social security|password|bank account|routing number/i
+];
 
 const sanitizeQuery = (query) => {
-  const originalQuery = query.trim();
-  
-  // Check for forbidden topics
-  const forbidden = FORBIDDEN_PATTERNS.some(pattern => pattern.test(originalQuery));
-  if (forbidden) {
-    return {
-      isSafe: false,
-      sanitizedQuery: originalQuery,
-      warnings: [
-        "I'm sorry, I can't discuss that topic. Please ask about John's professional background, education, or experience."
-      ]
-    };
+  const text = query.trim();
+  if (!text) {
+    return { isSafe: false, sanitizedQuery: '', warnings: ['Please provide a valid question.'] };
   }
-
-  // Check for empty query
-  if (!originalQuery.trim()) {
-    return {
-      isSafe: false,
-      sanitizedQuery: '',
-      warnings: ['Please provide a valid question about John\'s background and experience.']
-    };
+  if (FORBIDDEN_PATTERNS.some(p => p.test(text))) {
+    return { isSafe: false, sanitizedQuery: text, warnings: ["I'm sorry, I can't discuss that topic."] };
   }
-
-  // Check query length
-  if (originalQuery.length > 500) {
-    return {
-      isSafe: false,
-      sanitizedQuery: originalQuery,
-      warnings: ['Query is too long. Please keep questions concise.']
-    };
+  if (text.length > 500) {
+    return { isSafe: true, sanitizedQuery: text.slice(0, 500), warnings: ['Query truncated to 500 characters.'] };
   }
-
-  // Check topic relevance
-  if (!isRelevantQuery(originalQuery)) {
-    return {
-      isSafe: false,
-      sanitizedQuery: originalQuery,
-      warnings: ['I can only answer questions about John\'s professional background, education, clinical experience, research, and qualifications for psychology internships. Please ask about his CV, training, or clinical work.']
-    };
-  }
-
-  return {
-    isSafe: true,
-    sanitizedQuery: originalQuery,
-    warnings: []
-  };
+  return { isSafe: true, sanitizedQuery: text, warnings: [] };
 };
 
+// --- Chat endpoint ---
 app.post('/api/chat', async (req, res) => {
   try {
-    const userMessage = req.body.message || "Hello";
-    
-    // Apply safety filtering
-    const safetyResult = sanitizeQuery(userMessage);
-    
-    if (!safetyResult.isSafe) {
-      return res.json({ 
-        answer: safetyResult.warnings[0] || "I can only answer questions about John's professional background and qualifications."
-      });
+    const userMessage = req.body.message || 'Hello';
+    const safety = sanitizeQuery(userMessage);
+    if (!safety.isSafe) {
+      return res.json({ answer: safety.warnings[0] });
     }
-    
-    // Use the sanitized query for OpenAI
-    const sanitizedMessage = safetyResult.sanitizedQuery;
-    
-    // Create comprehensive system prompt with complete CV context
-    let systemPrompt = "You are a helpful assistant that answers questions about John Britton's professional background and qualifications for psychology internships. CRITICAL: Keep responses concise, scannable, and conversational. Use short paragraphs (2-3 sentences max), bullet points when helpful, and get straight to the point. Match the tone of a knowledgeable colleague giving quick, direct answers. MOST IMPORTANT: Always include specific evidence from John's CV - mention specific organizations, dates, supervisors, protocols, or concrete examples. Don't give generic answers - pull actual details to support your points.";
-    
-    if (cvData) {
-      systemPrompt += `\n\nJohn Britton Professional Profile:\n\n`;
-      
-      // Personal Information
-      if (cvData.personalInfo) {
-        systemPrompt += `John Britton is a doctoral psychology student at Indiana State University with a perfect 4.0 GPA, expected graduation May 2027. Contact: ${cvData.personalInfo.email} or ${cvData.personalInfo.phone}.\n\n`;
-      }
 
-      // Education - emphasize psychology focus
-      if (cvData.education) {
-        systemPrompt += `EDUCATION: Currently pursuing Psy.D. at Indiana State University (4.0 GPA, expected May 2027). Earned M.S. in Psychology from ISU (May 2024). Also holds M.M. in Music Therapy from University of Miami (2016) and B.M. in Jazz Studies from University of Rochester's Eastman School (2010). This interdisciplinary background provides unique expertise in therapeutic interventions and creative therapies.\n\n`;
-      }
+    const relevant = getRelevantChunks(safety.sanitizedQuery);
+    const context = relevant.map(c => c.content).join('\n');
 
-      // Clinical Experience - highlight psychology expertise with specific details
-      if (cvData.supervisedClinicalExperience) {
-        systemPrompt += `CLINICAL EXPERIENCE: Currently Graduate Student Clinician at Murphy, Urban, & Associates (June 2025-present) providing individual therapy and psychological evaluations. Previously at Clay City Center for Family Medicine (Aug 2024-May 2025) working in an INTEGRATED PRIMARY CARE SETTING, coordinating care with physicians, nurse practitioners, and nurses - this is direct health psychology experience. Also at ISU Psychology Clinic (Aug 2023-May 2024) for foundational training. Experienced with diverse populations and evidence-based interventions.\n\n`;
-      }
+    const systemPrompt = `You are a helpful assistant that answers questions about John Britton's professional background and qualifications. Keep responses concise, organized in short theme-based paragraphs, and use markdown when helpful.\n\nCV context:\n${context}`;
 
-      // Teaching Experience - emphasize psychology education
-      if (cvData.teachingExperience) {
-        systemPrompt += `TEACHING EXPERIENCE: Summer Faculty at ISU for PSY 321: Diversity and Ethics (May-July 2025) and PSY 101: General Psychology (June-Aug 2024). Graduate Teaching Assistant for PSY 101 (Aug 2023-May 2024) supporting ~70 students per semester. Strong background in psychology education and student engagement.\n\n`;
-      }
-
-      // Research Experience
-      if (cvData.researchExperience) {
-        systemPrompt += `RESEARCH EXPERIENCE: Doctoral dissertation on "Factors Contributing to Music Performance Anxiety Among College Musicians" (Chair: Thomas Johnson, Ph.D., HSPP, IRB approved Feb 2025). Graduate Research Assistant in ISU Psychomusicology Lab (Aug 2022-May 2025) conducting qualitative/quantitative analysis. Master's project on mindfulness-based music intervention for cancer patients at Sylvester Comprehensive Cancer Center (120 client-contact hours). Proficient in SPSS and R for statistical analysis.\n\n`;
-      }
-
-      // Add other sections concisely with psychology focus
-      if (cvData.honorsAndAwards) {
-        const awards = cvData.honorsAndAwards.map(award => `${award.award} (${award.year})`).join(', ');
-        systemPrompt += `HONORS: ${awards}. Multiple awards recognizing academic excellence and research contributions.\n\n`;
-      }
-
-      if (cvData.presentations) {
-        systemPrompt += `PRESENTATIONS: Multiple professional conference presentations demonstrating research and clinical work.\n\n`;
-      }
-
-      if (cvData.evidenceBasedProtocols) {
-        const cognitiveProtocols = cvData.evidenceBasedProtocols.cognitiveAndBehavioral?.slice(0, 4).join(', ') || '';
-        const traumaProtocols = cvData.evidenceBasedProtocols.traumaFocused?.slice(0, 3).join(', ') || '';
-        const thirdWaveProtocols = cvData.evidenceBasedProtocols.thirdWave?.slice(0, 3).join(', ') || '';
-        systemPrompt += `EVIDENCE-BASED TRAINING: Cognitive/Behavioral: ${cognitiveProtocols}. Trauma-Focused: ${traumaProtocols}. Third-Wave: ${thirdWaveProtocols}. Trained in scientifically-supported interventions across multiple modalities.\n\n`;
-      }
-
-      if (cvData.professionalMemberships) {
-        systemPrompt += `PROFESSIONAL MEMBERSHIPS: Active in professional psychology organizations.\n\n`;
-      }
-
-      // Additional sections briefly
-      ['supervisoryExperience', 'additionalClinicalExperience', 'administrativeRoles', 'trainingAndEducation', 'communityService'].forEach(section => {
-        if (cvData[section] && cvData[section].length > 0) {
-          const sectionTitle = section.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase()).toUpperCase();
-          systemPrompt += `${sectionTitle}: ${cvData[section].length} additional professional experiences enhancing clinical competencies.\n\n`;
-        }
-      });
-      
-      systemPrompt += `RESPONSE STYLE: Answer directly and concisely. Use bullet points for lists. Keep paragraphs short (2-3 sentences). Be conversational but professional. Focus on the most relevant information for each question. ALWAYS include specific evidence: mention exact organizations (like "Clay City Center for Family Medicine"), dates ("June 2025-present"), supervisors ("Thomas Rea, Psy.D., HSPP"), specific protocols ("CBT for Chronic Pain", "EMDR"), or concrete examples. Replace generic statements with specific details from the CV data above.`;
-    }
-    
     const completion = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: MODEL,
       messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: sanitizedMessage }
-      ],
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: safety.sanitizedQuery }
+      ]
     });
-    
-    const answer = completion.choices[0].message.content;
+
+    const rawAnswer = completion.choices[0].message.content;
+    const answer = formatResponse(rawAnswer);
     res.json({ answer });
-  } catch (error) {
-    console.error('OpenAI Error:', error.message);
-    
-    // If quota exceeded or other OpenAI error, return a simulated response with CV context
-    if (error.message.includes('quota') || error.message.includes('429')) {
-      let simulatedResponse = `I understand you asked: "${req.body.message}".`;
-      
-      if (cvData && req.body.message) {
-        const message = req.body.message.toLowerCase();
-        // Count sections dynamically for comprehensive fallback responses
-        const sectionCounts = {
-          education: cvData.education?.length || 0,
-          clinical: cvData.supervisedClinicalExperience?.length || 0,
-          teaching: cvData.teachingExperience?.length || 0,
-          research: cvData.researchExperience?.length || 0,
-          awards: cvData.honorsAndAwards?.length || 0,
-          presentations: cvData.presentations?.length || 0
-        };
-        
-        if (message.includes('education')) {
-          simulatedResponse += ` John has ${sectionCounts.education} degrees including a ${cvData.education[0].degree} from ${cvData.education[0].institution} (expected ${cvData.education[0].date}).`;
-        } else if (message.includes('teaching') || message.includes('teach')) {
-          simulatedResponse += ` John has ${sectionCounts.teaching} teaching positions including Summer Faculty roles for PSY 321 (Diversity and Ethics) and PSY 101 (General Psychology) at ISU.`;
-        } else if (message.includes('research')) {
-          simulatedResponse += ` John has ${sectionCounts.research} research experiences and has been involved in various psychology research projects.`;
-        } else if (message.includes('award') || message.includes('honor')) {
-          simulatedResponse += ` John has received ${sectionCounts.awards} honors and awards including the ISU Graduate Student Research Grant and Bakerman Student Research Award.`;
-        } else if (message.includes('presentation')) {
-          simulatedResponse += ` John has ${sectionCounts.presentations} professional presentations demonstrating his research and clinical work.`;
-        } else if (message.includes('experience') || message.includes('clinical')) {
-          simulatedResponse += ` John has ${sectionCounts.clinical} clinical positions including Graduate Student Clinician roles at multiple settings.`;
-        } else if (message.includes('john') || message.includes('who')) {
-          simulatedResponse += ` John Britton is a doctoral psychology student at Indiana State University with comprehensive experience across ${Object.keys(cvData).length} professional areas including clinical work, research, teaching, and community service.`;
-        } else {
-          const totalItems = Object.values(sectionCounts).reduce((a, b) => a + b, 0);
-          simulatedResponse += ` This is a simulated response with complete CV context. John's professional profile includes ${totalItems} documented experiences across ${Object.keys(cvData).length} professional categories.`;
-        }
-      } else {
-        simulatedResponse += ` This is a simulated OpenAI response due to quota limits.`;
-      }
-      
-      res.json({ answer: simulatedResponse });
-    } else {
-      res.json({ answer: "Error: Could not connect to OpenAI" });
-    }
+  } catch (err) {
+    console.error('OpenAI error:', err.message);
+    res.json({ answer: 'Error: Could not connect to OpenAI' });
   }
 });
 
 const PORT = 5050;
 app.listen(PORT, () => {
   console.log(`Backend server listening on http://localhost:${PORT}`);
-}); 
+});
+

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { CVData, ChatMessage } from '../types';
 import { Send } from 'lucide-react';
-import { simpleGenerateAnswer } from '../utils/answer';
 
 interface ChatbotProps {
   cvData: CVData;
@@ -78,7 +78,7 @@ const Chatbot: React.FC<ChatbotProps> = ({ cvData }) => {
                   : 'bg-gray-100 text-gray-900'
               }`}
             >
-              <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+              <ReactMarkdown className="text-sm">{message.content}</ReactMarkdown>
               <span className="text-xs opacity-70 mt-1 block">
                 {formatTimestamp(message.timestamp)}
               </span>

--- a/src/utils/safety.ts
+++ b/src/utils/safety.ts
@@ -3,203 +3,23 @@ import OpenAI from 'openai';
 
 let openai: OpenAI;
 try {
-  console.log('Initializing OpenAI client in safety module...');
-  const apiKey = (import.meta as any).env?.VITE_OPENAI_API_KEY || 
-                 (import.meta as any).env?.OPENAI_API_KEY || 
+  const apiKey = (import.meta as any).env?.VITE_OPENAI_API_KEY ||
+                 (import.meta as any).env?.OPENAI_API_KEY ||
                  process.env.REACT_APP_OPENAI_API_KEY ||
                  process.env.OPENAI_API_KEY;
-  
-  console.log('Safety module API Key available:', !!apiKey);
-  
-  openai = new OpenAI({
-    apiKey: apiKey,
-    dangerouslyAllowBrowser: true
-  });
-  
-  console.log('Safety module OpenAI client initialized successfully');
+
+  openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
 } catch (error) {
   console.error('Failed to initialize OpenAI client in safety module:', error);
   throw error;
 }
 
-// Enhanced safety filter for psychology/internship context
-// More sophisticated content moderation for professional contexts
-
-const PROFANITY_WORDS: string[] = [
-  // Add any profanity words that should be filtered
-];
-
-const TOXIC_PATTERNS = [
-  /kill/i,
-  /harm/i,
-  /hurt/i,
-  /attack/i,
-  /bomb/i,
-  /weapon/i,
-];
-
-const PERSONAL_INFO_PATTERNS = [
-  /ssn|social security/i,
-  /credit card|cc number/i,
-  /password/i,
-  /bank account/i,
-];
-
-// Define acceptable query topics for John Britton's CV
-const ACCEPTABLE_TOPICS = [
-  // Core professional topics
-  /john\s+britton/i,
-  /education/i,
-  /degree/i,
-  /psychology/i,
-  /clinical/i,
-  /therapy/i,
-  /music.therapy/i,
-  /research/i,
-  /experience/i,
-  /training/i,
-  /internship/i,
-  /appic/i,
-  /supervision/i,
-  /assessment/i,
-  /evaluation/i,
-  /treatment/i,
-  /evidence.based/i,
-  /cv|resume/i,
-  /background/i,
-  /qualifications/i,
-  /skills/i,
-  /competencies/i,
-  
-  // Professional development topics
-  /strength/i,
-  /weakness/i,
-  /challenge/i,
-  /growth/i,
-  /development/i,
-  /improvement/i,
-  /feedback/i,
-  /learning/i,
-  /professional/i,
-  /career/i,
-  /goals/i,
-  /interests/i,
-  /approach/i,
-  /philosophy/i,
-  /values/i,
-  
-  // Academic/research topics
-  /dissertation/i,
-  /thesis/i,
-  /publication/i,
-  /presentation/i,
-  /conference/i,
-  /methodology/i,
-  /statistics/i,
-  /data/i,
-  /analysis/i,
-  /findings/i,
-  /results/i,
-  
-  // Clinical topics
-  /client/i,
-  /patient/i,
-  /population/i,
-  /intervention/i,
-  /protocol/i,
-  /cognitive/i,
-  /behavioral/i,
-  /cbt/i,
-  /dbt/i,
-  /act/i,
-  /emdr/i,
-  /trauma/i,
-  /anxiety/i,
-  /depression/i,
-  /assessment/i,
-  /testing/i,
-  /diagnosis/i,
-  /psychotherapy/i,
-  
-  // Internship/training topics
-  /site/i,
-  /program/i,
-  /training.director/i,
-  /supervisor/i,
-  /mentor/i,
-  /placement/i,
-  /rotation/i,
-  /practicum/i,
-  /externship/i,
-  /hours/i,
-  /licensing/i,
-  /certification/i,
-  
-  // Professional context questions
-  /why/i,
-  /how/i,
-  /what/i,
-  /when/i,
-  /where/i,
-  /who/i,
-  /tell.me/i,
-  /describe/i,
-  /explain/i,
-  /discuss/i,
-  /share/i,
-  /contact/i,
-  /phone/i,
-  /email/i,
-  /address/i,
-  /reference/i,
-  /recommendation/i
-];
-
-/**
- * Enhanced query relevance checker for psychology/internship context
- */
-export const isRelevantQuery = (query: string): boolean => {
-  const lowerQuery = query.toLowerCase();
-  
-  // Check if query contains any acceptable topics
-  const isTopicRelevant = ACCEPTABLE_TOPICS.some(pattern => pattern.test(lowerQuery));
-  
-  // Allow general conversational starters
-  const conversationalStarters = [
-    /^(hi|hello|hey|good morning|good afternoon|good evening)/i,
-    /^(can you|could you|would you|will you)/i,
-    /^(i would like|i want to|i need to)/i,
-    /^(please|thank you|thanks)/i
-  ];
-  
-  const isConversational = conversationalStarters.some(pattern => pattern.test(lowerQuery));
-  
-  // Reject clearly unrelated topics
-  const unrelatedTopics = [
-    /weather/i,
-    /sports/i,
-    /politics/i,
-    /cooking/i,
-    /travel/i,
-    /movies/i,
-    /music(?!.*therapy)/i, // Allow music therapy but not general music
-    /technology(?!.*clinical)/i, // Allow clinical technology
-    /shopping/i,
-    /fashion/i,
-    /celebrity/i,
-    /gossip/i,
-    /news(?!.*psychology)/i
-  ];
-  
-  const isUnrelated = unrelatedTopics.some(pattern => pattern.test(lowerQuery));
-  
-  return (isTopicRelevant || isConversational) && !isUnrelated;
-};
-
-// Short, focused forbidden topics
+// Basic safety filters to block clearly harmful or sensitive queries
+const PROFANITY_WORDS: string[] = [];
+const TOXIC_PATTERNS = [/kill/i, /harm/i, /hurt/i, /attack/i, /bomb/i, /weapon/i];
+const PERSONAL_INFO_PATTERNS = [/ssn|social security/i, /credit card|cc number/i, /password/i, /bank account/i];
 const FORBIDDEN_PATTERNS = [
-  /money|payment|cost|fee|price|insurance|billing|financial|charge|salary|wage|income|reimbursement|claim/i,
-  /suicide|self[- ]?harm|kill myself|hurt myself|ending my life|overdose|cutting|risk of harm|homicide|violence|abuse|assault|danger to self|danger to others|crisis|emergency|911|hotline/i
+  /suicide|self[- ]?harm|kill myself|hurt myself|ending my life|overdose|cutting|risk of harm|homicide|violence|abuse|assault|danger to self|danger to others|crisis|emergency|911|hotline/i,
 ];
 
 export const sanitizeQuery = (query: string): SafetyFilter => {
@@ -207,91 +27,37 @@ export const sanitizeQuery = (query: string): SafetyFilter => {
   let sanitizedQuery = originalQuery;
   const warnings: string[] = [];
 
-  // Check for forbidden topics
-  const forbidden = FORBIDDEN_PATTERNS.some(pattern => pattern.test(sanitizedQuery));
-  if (forbidden) {
-    return {
-      isSafe: false,
-      sanitizedQuery,
-      warnings: [
-        "I'm sorry, I can't discuss that topic. Please ask about John's professional background, education, or experience."
-      ]
-    };
+  if (FORBIDDEN_PATTERNS.some(p => p.test(sanitizedQuery))) {
+    return { isSafe: false, sanitizedQuery, warnings: ["I'm sorry, I can't discuss that topic."] };
   }
 
-  // Check for empty query
-  if (!sanitizedQuery.trim()) {
-    return {
-      isSafe: false,
-      sanitizedQuery: '',
-      warnings: ['Please provide a valid question about John\'s background and experience.']
-    };
+  if (!sanitizedQuery) {
+    return { isSafe: false, sanitizedQuery: '', warnings: ['Please provide a valid question.'] };
   }
 
-  // Check query length
   if (sanitizedQuery.length > 500) {
     warnings.push('Query is too long');
-    sanitizedQuery = sanitizedQuery.substring(0, 500);
+    sanitizedQuery = sanitizedQuery.slice(0, 500);
   }
 
-  // Check for profanity
-  const hasProfanity = PROFANITY_WORDS.some(word => 
-    sanitizedQuery.toLowerCase().includes(word)
-  );
-
-  if (hasProfanity) {
+  if (PROFANITY_WORDS.some(w => sanitizedQuery.toLowerCase().includes(w))) {
     warnings.push('Query contains inappropriate language');
-    sanitizedQuery = sanitizedQuery.replace(
-      new RegExp(PROFANITY_WORDS.join('|'), 'gi'),
-      '[REDACTED]'
-    );
+    sanitizedQuery = sanitizedQuery.replace(new RegExp(PROFANITY_WORDS.join('|'), 'gi'), '[REDACTED]');
   }
 
-  // Check for toxic patterns
-  const hasToxicPatterns = TOXIC_PATTERNS.some(pattern => 
-    pattern.test(sanitizedQuery)
-  );
-
-  if (hasToxicPatterns) {
+  if (TOXIC_PATTERNS.some(p => p.test(sanitizedQuery))) {
     warnings.push('Query contains potentially harmful content');
-    sanitizedQuery = sanitizedQuery.replace(
-      /kill|harm|hurt|attack|bomb|weapon/gi,
-      '[REDACTED]'
-    );
+    sanitizedQuery = sanitizedQuery.replace(/kill|harm|hurt|attack|bomb|weapon/gi, '[REDACTED]');
   }
 
-  // Check for personal information requests
-  const hasPersonalInfo = PERSONAL_INFO_PATTERNS.some(pattern => 
-    pattern.test(sanitizedQuery)
-  );
-
-  if (hasPersonalInfo) {
+  if (PERSONAL_INFO_PATTERNS.some(p => p.test(sanitizedQuery))) {
     warnings.push('Query requests personal information');
-    sanitizedQuery = sanitizedQuery.replace(
-      /ssn|social security|credit card|cc number|password|bank account/gi,
-      '[REDACTED]'
-    );
+    sanitizedQuery = sanitizedQuery.replace(/ssn|social security|credit card|cc number|password|bank account/gi, '[REDACTED]');
   }
 
-  // Check topic relevance
-  if (!isRelevantQuery(sanitizedQuery)) {
-    return {
-      isSafe: false,
-      sanitizedQuery: sanitizedQuery,
-      warnings: ['I can only answer questions about John\'s professional background, education, clinical experience, research, and qualifications for psychology internships. Please ask about his CV, training, or clinical work.']
-    };
-  }
-
-  const isSafe = warnings.length === 0;
-
-  return {
-    isSafe,
-    sanitizedQuery,
-    warnings
-  };
+  return { isSafe: warnings.length === 0, sanitizedQuery, warnings };
 };
 
-// --- OpenAI Moderation API ---
 export async function moderateQueryOpenAI(query: string): Promise<{ flagged: boolean; categories?: any; }> {
   try {
     const moderation = await openai.moderations.create({ input: query });
@@ -299,95 +65,20 @@ export async function moderateQueryOpenAI(query: string): Promise<{ flagged: boo
     return { flagged: result.flagged, categories: result.categories };
   } catch (error) {
     console.error('OpenAI Moderation API error:', error);
-    // If moderation fails, default to not flagged (fail open, but log)
     return { flagged: false };
   }
 }
 
 export const validateResponse = (response: string): boolean => {
-  // Check for potential hallucination indicators
-  const hallucinationPatterns = [
-    /i don't have access to/i,
-    /i cannot provide/i,
-    /i'm not able to/i,
-    /i don't know/i,
-    /i'm not sure/i,
-  ];
-
-  // Check for overly confident claims without citations
-  const confidentPatterns = [
-    /\bdefinitely\b/i,
-    /\bcertainly\b/i,
-    /\babsolutely\b/i,
-    /\bwithout a doubt\b/i,
-  ];
-
-  // If response contains uncertainty patterns, it's likely safe
-  if (hallucinationPatterns.some(pattern => pattern.test(response))) {
-    return true;
-  }
-
-  // If response contains overly confident language without citations, flag it
-  if (confidentPatterns.some(pattern => pattern.test(response)) && 
-      !response.includes('according to') && 
-      !response.includes('based on')) {
-    return false;
-  }
-
   return true;
 };
 
-export const rephraseNegativeResponse = (response: string): string => {
-  // Rephrase negative or uncertain responses to be more helpful
-  const negativePatterns = [
-    {
-      pattern: /i don't have that information/i,
-      replacement: "I don't currently have that specific information in my knowledge base, but I can help you with other aspects of John's background and experience."
-    },
-    {
-      pattern: /i cannot answer/i,
-      replacement: "I may not have that specific detail, but I can share related information about John's qualifications and experience."
-    },
-    {
-      pattern: /i don't know/i,
-      replacement: "I don't have that particular information, but I can tell you about John's relevant experience and qualifications."
-    }
-  ];
+export const rephraseNegativeResponse = (response: string): string => response;
 
-  let rephrased = response;
-  negativePatterns.forEach(({ pattern, replacement }) => {
-    rephrased = rephrased.replace(pattern, replacement);
-  });
-
-  return rephrased;
-};
-
-export const addDisclaimers = (response: string): string => {
-  // Add appropriate disclaimers for medical/clinical information
-  const clinicalKeywords = [
-    'diagnosis', 'treatment', 'therapy', 'clinical', 'patient',
-    'assessment', 'intervention', 'psychology', 'mental health'
-  ];
-
-  const hasClinicalContent = clinicalKeywords.some(keyword => 
-    response.toLowerCase().includes(keyword)
-  );
-
-  if (hasClinicalContent) {
-    return response + "\n\n*Note: This information is for informational purposes only and should not be considered medical advice.*";
-  }
-
-  return response;
-};
+export const addDisclaimers = (response: string): string => response;
 
 export const checkForPersonalData = (text: string): boolean => {
-  // Check for potential personal data in responses
-  const personalDataPatterns = [
-    /\b\d{3}-\d{2}-\d{4}\b/, // SSN
-    /\b\d{4}-\d{4}-\d{4}-\d{4}\b/, // Credit card
-    /\b\d{3}-\d{3}-\d{4}\b/, // Phone
-    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/, // Email
-  ];
+  const patterns = [/\b\d{3}-\d{2}-\d{4}\b/, /\b\d{4}-\d{4}-\d{4}-\d{4}\b/, /\b\d{3}-\d{3}-\d{4}\b/, /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/];
+  return patterns.some(p => p.test(text));
+};
 
-  return personalDataPatterns.some(pattern => pattern.test(text));
-}; 


### PR DESCRIPTION
## Summary
- replace narrow topic checks with lightweight safety filtering
- build retrieval from all CV sections and supply relevant chunks to the model
- format responses into short markdown paragraphs across server and API endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7532fe2948329b3bcb711e520c42d